### PR TITLE
feat(web): add tablet + mobile responsive layer across all 20 pages

### DIFF
--- a/frontend/app/(marketing)/landing/page.module.css
+++ b/frontend/app/(marketing)/landing/page.module.css
@@ -131,8 +131,36 @@ footer.foot {
   color: var(--text-primary);
 }
 
-@media (max-width: 820px) {
+/* ---- responsive ---- */
+@media (max-width: 1023px) {
   .navLinks {
     display: none;
+  }
+  .block {
+    padding: var(--sp-8) 0;
+  }
+}
+@media (max-width: 767px) {
+  .wrap {
+    padding: 0 var(--sp-4);
+  }
+  .navInner {
+    gap: var(--sp-3);
+  }
+  .trust {
+    gap: var(--sp-4);
+    padding: var(--sp-6) 0;
+  }
+  .block {
+    padding: var(--sp-7) 0;
+  }
+  .footInner {
+    flex-direction: column;
+    align-items: flex-start;
+    gap: var(--sp-3);
+  }
+  .footLinks {
+    margin-left: 0;
+    flex-wrap: wrap;
   }
 }

--- a/frontend/app/(marketing)/welcome/page.module.css
+++ b/frontend/app/(marketing)/welcome/page.module.css
@@ -166,3 +166,31 @@
   outline: none;
   box-shadow: var(--shadow-focus);
 }
+
+/* ---- responsive ---- */
+@media (max-width: 1023px) {
+  .stage {
+    place-items: start center;
+    padding: var(--sp-5);
+  }
+}
+@media (max-width: 767px) {
+  .stage {
+    padding: var(--sp-4);
+  }
+  .steps {
+    padding: var(--sp-5) var(--sp-5) 0;
+  }
+  .stepLabel,
+  .body {
+    padding-left: var(--sp-5);
+    padding-right: var(--sp-5);
+  }
+  .footer {
+    padding: var(--sp-4) var(--sp-5) var(--sp-6);
+    flex-wrap: wrap;
+  }
+  .hero h1 {
+    font-size: var(--fs-xl);
+  }
+}

--- a/frontend/app/(workbench)/chat/page.module.css
+++ b/frontend/app/(workbench)/chat/page.module.css
@@ -161,3 +161,15 @@
 .switcher button { border: 0; background: transparent; color: var(--text-tertiary);
   font-size: var(--fs-xs); padding: 4px 10px; border-radius: var(--r-pill); }
 .switcherOn { background: var(--accent-subtle); color: var(--accent-ink); }
+
+/* ---- responsive ---- */
+@media (max-width: 1023px) {
+  .convos { display: none; }
+  .shell { flex-direction: column; }
+}
+@media (max-width: 767px) {
+  .row { padding: var(--sp-2) var(--sp-3); }
+  .msg { max-width: 100%; }
+  .suggest { grid-template-columns: 1fr; }
+  .center { padding: var(--sp-5); }
+}

--- a/frontend/app/(workbench)/deepsearch/page.module.css
+++ b/frontend/app/(workbench)/deepsearch/page.module.css
@@ -149,3 +149,13 @@
                 border-radius: var(--r-lg); padding: var(--sp-4); margin-bottom: var(--sp-3);
                 display: flex; flex-direction: column; gap: var(--sp-2); }
 .skelGap { height: var(--sp-2); }
+
+/* ---- responsive ---- */
+@media (max-width: 1023px) {
+  .research { grid-template-columns: 1fr; }
+}
+@media (max-width: 767px) {
+  .body { padding: var(--sp-3); }
+  .querywrap { min-width: 0; }
+  .answerMeta { gap: var(--sp-2); }
+}

--- a/frontend/app/(workbench)/developer/evaluators/page.module.css
+++ b/frontend/app/(workbench)/developer/evaluators/page.module.css
@@ -108,3 +108,18 @@
   padding: var(--sp-2) var(--sp-3); font-family: inherit; font-size: var(--fs-sm); }
 .sfld textarea { font-family: var(--font-mono); font-size: var(--fs-xs); min-height: 72px; resize: vertical; }
 .srow { display: flex; gap: var(--sp-2); justify-content: flex-end; margin-top: var(--sp-4); }
+
+/* ---- responsive ---- */
+@media (max-width: 1023px) {
+  .wrap { padding: var(--sp-4) var(--sp-5); gap: var(--sp-5); }
+  .meter { grid-template-columns: 120px 1fr 48px 96px; }
+}
+@media (max-width: 767px) {
+  .wrap { padding: var(--sp-4); }
+  .meter { grid-template-columns: 1fr auto; gap: var(--sp-1) var(--sp-2); }
+  .meter .track { grid-column: 1 / -1; }
+  .meter .val, .meter .pf { text-align: right; }
+  .skelMeter { grid-template-columns: 1fr auto; }
+  .skelMeter > :last-child { grid-column: 1 / -1; }
+  .jobbar { flex-wrap: wrap; padding-left: var(--sp-4); padding-right: var(--sp-4); }
+}

--- a/frontend/app/(workbench)/developer/flows/page.module.css
+++ b/frontend/app/(workbench)/developer/flows/page.module.css
@@ -184,3 +184,16 @@
 .flowmini { display: block; font-family: var(--font-mono); font-size: var(--fs-xs); color: var(--text-secondary);
   margin-top: var(--sp-2); background: var(--bg-primary); border: 1px solid var(--border-subtle);
   border-radius: var(--r-sm); padding: var(--sp-2); overflow: hidden; text-overflow: ellipsis; white-space: nowrap; }
+
+/* ---- responsive ---- */
+@media (max-width: 1023px) {
+  .builder { grid-template-columns: 1fr; min-height: 0; }
+  .palette { border-right: 0; border-bottom: 1px solid var(--border-subtle); max-height: 240px; }
+  .inspector { border-left: 0; border-top: 1px solid var(--border-subtle); }
+  .canvas { min-height: 360px; }
+}
+@media (max-width: 767px) {
+  .tmplGrid { grid-template-columns: 1fr; }
+  .top { padding-left: var(--sp-4); padding-right: var(--sp-4); }
+  .libpop { width: min(320px, 90vw); }
+}

--- a/frontend/app/(workbench)/developer/maestro/page.module.css
+++ b/frontend/app/(workbench)/developer/maestro/page.module.css
@@ -154,3 +154,16 @@
   padding: var(--sp-4) var(--sp-5); }
 .skelTerm { min-height: 150px; border: 1px solid var(--border-subtle); border-radius: var(--r-md);
   background: var(--surface-card); padding: var(--sp-3); display: flex; flex-direction: column; gap: var(--sp-2); }
+
+/* ---- responsive ---- */
+@media (max-width: 1023px) {
+  .split { grid-template-columns: minmax(200px, 240px) 1fr; }
+  .grid, .skelGrid { grid-template-columns: 1fr; }
+  .picker { grid-template-columns: 1fr; }
+}
+@media (max-width: 767px) {
+  .split { grid-template-columns: 1fr; }
+  .conductor { border-right: 0; border-bottom: 1px solid var(--border-subtle); }
+  .chipbar, .presetbar { padding-left: var(--sp-4); padding-right: var(--sp-4); }
+  .grid, .skelGrid { padding-left: var(--sp-4); padding-right: var(--sp-4); }
+}

--- a/frontend/app/(workbench)/developer/page.module.css
+++ b/frontend/app/(workbench)/developer/page.module.css
@@ -161,3 +161,17 @@
             border-radius: var(--r-md); padding: var(--sp-4); display: flex; flex-direction: column; gap: var(--sp-2); }
 .boot { color: var(--text-tertiary); font-size: var(--fs-xs); font-family: var(--font-mono); }
 .bootBody { display: flex; flex-direction: column; gap: var(--sp-2); }
+
+/* ---- responsive ---- */
+@media (max-width: 1023px) {
+  .statGrid { grid-template-columns: repeat(2, 1fr); }
+  .body { padding: var(--sp-4); }
+  .alias { width: 160px; }
+}
+@media (max-width: 767px) {
+  .statGrid { grid-template-columns: 1fr; }
+  .keyRow, .routeRow, .urlRow { flex-wrap: wrap; }
+  .alias { width: auto; flex: 1 1 100%; }
+  .keyMono { flex: 1 1 100%; }
+  .keyActions { width: 100%; }
+}

--- a/frontend/app/(workbench)/documents/page.module.css
+++ b/frontend/app/(workbench)/documents/page.module.css
@@ -177,3 +177,18 @@
 .fmtchips { display: flex; flex-wrap: wrap; gap: 6px; justify-content: center; max-width: 540px; justify-self: center; }
 .fmtchip { font-size: var(--fs-xs); color: var(--text-secondary); background: var(--surface-card);
   border: 1px solid var(--border-default); border-radius: var(--r-pill); padding: 3px var(--sp-3); }
+
+/* ---- responsive ---- */
+@media (max-width: 1023px) {
+  .split { grid-template-columns: 1fr; }
+  .library { border-right: 0; border-bottom: 1px solid var(--border-subtle); }
+  .search { width: 100%; }
+}
+@media (max-width: 767px) {
+  .figgrid { grid-template-columns: 1fr; }
+  .field { grid-template-columns: 1fr; gap: var(--sp-1); }
+  .inspHead, .tabbody, .library { padding-left: var(--sp-4); padding-right: var(--sp-4); }
+  .tabs { padding: 0 var(--sp-4); overflow-x: auto; }
+  .jobbar { padding-left: var(--sp-4); padding-right: var(--sp-4); flex-wrap: wrap; }
+  .dropzone { padding: var(--sp-6) var(--sp-5); }
+}

--- a/frontend/app/(workbench)/extensions/page.module.css
+++ b/frontend/app/(workbench)/extensions/page.module.css
@@ -143,3 +143,20 @@
   background: var(--surface-card); padding: var(--sp-4); text-align: left; }
 .recoCard .extIco { margin-bottom: var(--sp-2); }
 .recoBtn { margin-top: var(--sp-2); }
+
+/* ---- responsive ---- */
+@media (max-width: 1023px) {
+  .split { grid-template-columns: 1fr; }
+  .browse { border-right: 0; border-bottom: 1px solid var(--border-subtle); }
+  .reco { grid-template-columns: repeat(2, 1fr); }
+  .search { width: 100%; }
+}
+@media (max-width: 767px) {
+  .reco { grid-template-columns: 1fr; }
+  .req { grid-template-columns: 1fr; gap: var(--sp-1); }
+  .browse, .tabBody { padding-left: var(--sp-4); padding-right: var(--sp-4); }
+  .detHead { padding-left: var(--sp-4); padding-right: var(--sp-4); }
+  .tabs { padding: 0 var(--sp-4); overflow-x: auto; }
+  .cats { padding-left: var(--sp-4); padding-right: var(--sp-4); }
+  .shellbar { padding-left: var(--sp-4); padding-right: var(--sp-4); flex-wrap: wrap; }
+}

--- a/frontend/app/(workbench)/forecasting/page.module.css
+++ b/frontend/app/(workbench)/forecasting/page.module.css
@@ -172,3 +172,20 @@
          color: var(--error-ink); font-size: 16px; line-height: 1; padding: 0 4px;
          cursor: pointer; opacity: .7; }
 .discX:hover { opacity: 1; }
+
+/* ---- responsive ---- */
+@media (max-width: 1023px) {
+  .split { flex-direction: column; }
+  .ctrl { width: 100%; flex: none; border-right: 0;
+          border-bottom: 1px solid var(--border-subtle); }
+  .statgrid { grid-template-columns: repeat(2, 1fr); }
+}
+@media (max-width: 767px) {
+  .statgrid { grid-template-columns: 1fr; }
+  .fieldRow2 { grid-template-columns: 1fr; }
+  .ctrl, .scroll { padding: var(--sp-4); }
+  .outputTop { padding-left: var(--sp-4); padding-right: var(--sp-4); }
+  .jobbar { padding-left: var(--sp-4); padding-right: var(--sp-4); }
+  .disclaimer { padding-left: var(--sp-4); padding-right: var(--sp-4); }
+  .tbl { font-size: var(--fs-xs); }
+}

--- a/frontend/app/(workbench)/layout.tsx
+++ b/frontend/app/(workbench)/layout.tsx
@@ -1,9 +1,13 @@
+import MobileNav from '@/app/components/MobileNav';
 import Sidebar from '@/app/components/Sidebar';
 
 export default function WorkbenchLayout({ children }: { children: React.ReactNode }) {
   return (
     <div className="app">
-      <Sidebar />
+      <div className="deskNav">
+        <Sidebar />
+      </div>
+      <MobileNav />
       <div className="main">{children}</div>
     </div>
   );

--- a/frontend/app/(workbench)/models/[id]/page.module.css
+++ b/frontend/app/(workbench)/models/[id]/page.module.css
@@ -104,3 +104,14 @@
   padding: var(--sp-2) var(--sp-4); border-radius: var(--r-md); font-size: var(--fs-sm);
   transition: background var(--dur-fast) var(--ease-default); }
 .btnDanger:hover { background: var(--error-bg); }
+
+@media (max-width: 1023px) {
+  .scroll { padding: var(--sp-4); }
+  .benchGrid { grid-template-columns: repeat(2, 1fr); }
+}
+@media (max-width: 767px) {
+  .benchGrid { grid-template-columns: 1fr; }
+  .idRows { grid-template-columns: 1fr; gap: var(--sp-micro) 0; }
+  .idRows dt { margin-top: var(--sp-2); }
+  .specRow { flex-direction: column; gap: var(--sp-micro); }
+}

--- a/frontend/app/(workbench)/models/add/page.module.css
+++ b/frontend/app/(workbench)/models/add/page.module.css
@@ -76,3 +76,14 @@
 
 /* loading skeleton */
 .skelField { display: grid; gap: var(--sp-2); margin-bottom: var(--sp-5); }
+
+@media (max-width: 1023px) {
+  .scroll { padding: var(--sp-4); }
+}
+@media (max-width: 767px) {
+  .pathRow { flex-direction: column; }
+  .browseBtn { width: 100%; }
+  .formActions { flex-direction: column; align-items: stretch; }
+  .cancel, .ctaPrimary { justify-content: center; }
+  .ctaRow { flex-direction: column; align-items: stretch; }
+}

--- a/frontend/app/(workbench)/models/browse/page.module.css
+++ b/frontend/app/(workbench)/models/browse/page.module.css
@@ -8,7 +8,6 @@
                    font-size: var(--fs-xs); padding: var(--sp-1) var(--sp-3); border-radius: var(--r-pill); }
 .switchOn { background: var(--accent-subtle); color: var(--accent-ink); }
 
-
 /* ---- off-device advisory ---- */
 .advisory { display: flex; align-items: center; gap: var(--sp-2); padding: var(--sp-2) var(--sp-6);
             font-size: var(--fs-xs); color: var(--text-tertiary); background: var(--bg-tertiary);
@@ -190,3 +189,12 @@
 .btnSelClear { background: transparent; color: var(--text-inverse); border: 1px solid var(--border-default);
                font-size: var(--fs-sm); padding: var(--sp-2) var(--sp-4); border-radius: var(--r-md); }
 .btnSelClear:hover { background: var(--accent-hover); }
+@media (max-width: 1023px) {
+  .featured { grid-template-columns: repeat(2, 1fr); }
+  .results { padding: var(--sp-3) var(--sp-4); } }
+@media (max-width: 767px) {
+  .featured { grid-template-columns: 1fr; }
+  .controls, .selBar { flex-wrap: wrap; }
+  .searchHf { flex-basis: 100%; }
+  .sourceToggle, .sortModes { flex: 1; }
+  .repoStats { justify-content: flex-start; } }

--- a/frontend/app/(workbench)/models/online/page.module.css
+++ b/frontend/app/(workbench)/models/online/page.module.css
@@ -169,3 +169,18 @@
 .note { font-size: var(--fs-xs); color: var(--text-tertiary); line-height: var(--lh-normal); }
 .note strong { color: var(--text-secondary); }
 .keyformCta { align-self: flex-start; }
+
+@media (max-width: 1023px) {
+  .provlist { width: 180px; }
+  .panel { padding: var(--sp-4); }
+  .search { width: 200px; }
+}
+@media (max-width: 767px) {
+  .content { flex-direction: column; }
+  .provlist { width: 100%; flex: none; border-right: 0;
+    border-bottom: 1px solid var(--border-subtle); max-height: 180px; }
+  .search { width: 100%; }
+  .mcardMeta { grid-template-columns: 1fr; }
+  .mcardFoot { flex-wrap: wrap; }
+  .selBar { flex-wrap: wrap; }
+}

--- a/frontend/app/(workbench)/models/page.module.css
+++ b/frontend/app/(workbench)/models/page.module.css
@@ -34,3 +34,13 @@
   animation: pulse 1.2s infinite; }
 @keyframes pulse { 50% { opacity: 0.5; } }
 .msg { color: var(--text-dim); font-size: 12px; margin-top: 8px; }
+
+@media (max-width: 1023px) {
+  .wrap { padding: 16px; }
+}
+@media (max-width: 767px) {
+  .toolbar { flex-wrap: wrap; }
+  .search { flex-basis: 100%; }
+  .add { flex-direction: column; align-items: stretch; }
+  .add input { width: 100%; }
+}

--- a/frontend/app/(workbench)/models/providers/page.module.css
+++ b/frontend/app/(workbench)/models/providers/page.module.css
@@ -183,3 +183,17 @@
 .secureNote { display: flex; align-items: flex-start; gap: var(--sp-2); font-size: var(--fs-xs);
               color: var(--text-tertiary); background: var(--bg-tertiary); border-radius: var(--r-md); padding: var(--sp-2) var(--sp-3); }
 .dialogFoot { display: flex; gap: var(--sp-2); justify-content: flex-end; flex-wrap: wrap; }
+
+@media (max-width: 1023px) {
+  .body { padding: var(--sp-4); }
+  .table { overflow-x: auto; }
+  .thead, .row { min-width: 760px; }
+}
+@media (max-width: 767px) {
+  .gwTop { flex-wrap: wrap; }
+  .keyRow { flex-wrap: wrap; }
+  .keyInputWrap { flex-basis: 100%; }
+  .paths { flex-direction: column; align-items: stretch; }
+  .pathCard { max-width: none; }
+  .dialog { width: 100%; }
+}

--- a/frontend/app/(workbench)/page.module.css
+++ b/frontend/app/(workbench)/page.module.css
@@ -134,3 +134,17 @@
 .switcher button { border: 0; background: transparent; color: var(--text-tertiary);
   font-size: var(--fs-xs); padding: 4px 10px; border-radius: var(--r-pill); }
 .switcher button.on { background: var(--accent-subtle); color: var(--accent-ink); }
+
+/* ---- responsive ---- */
+@media (max-width: 1023px) {
+  .grid { grid-template-columns: 1fr; }
+  .col7, .col5, .col12 { grid-column: span 1; }
+  .featCards { grid-template-columns: repeat(2, 1fr); }
+}
+@media (max-width: 767px) {
+  .canvas { padding: var(--sp-3); }
+  .heroRow { flex-wrap: wrap; }
+  .heroStats { grid-template-columns: 1fr; }
+  .qaGrid, .tips, .featCards { grid-template-columns: 1fr; }
+  .docCounts { grid-template-columns: 1fr; }
+}

--- a/frontend/app/(workbench)/settings/page.module.css
+++ b/frontend/app/(workbench)/settings/page.module.css
@@ -179,3 +179,22 @@
              transition: background var(--dur-fast) var(--ease-default); }
 .btnDanger:hover:not(:disabled) { background: var(--error-bg); }
 .btnDanger:disabled { opacity: 0.4; cursor: not-allowed; }
+
+/* ---- responsive ---- */
+@media (max-width: 1023px) {
+  .shell { flex-direction: column; min-height: 0; }
+  .nav { width: 100%; flex: none; flex-direction: row; flex-wrap: wrap; border-right: 0;
+         border-bottom: 1px solid var(--border-subtle); padding: var(--sp-2) var(--sp-3);
+         gap: var(--sp-1); overflow-x: auto; }
+  .navTitle, .navSpacer, .navFoot, .navSearch { display: none; }
+  .navLink { width: auto; border-radius: var(--r-pill); padding: var(--sp-1) var(--sp-3); border-left: 0; }
+  .navLink.active { border-left: 0; } .panel { padding: var(--sp-5); }
+}
+@media (max-width: 767px) {
+  .field { flex-direction: column; align-items: stretch; gap: var(--sp-2); }
+  .fieldLabel { flex: none; }
+  .control { width: 100%; }
+  .select, .textInput, .range { max-width: none; min-width: 0; width: 100%; }
+  .panel { padding: var(--sp-4); }
+  .meterLabel { width: 110px; }
+}

--- a/frontend/app/(workbench)/speech/page.module.css
+++ b/frontend/app/(workbench)/speech/page.module.css
@@ -173,3 +173,20 @@
 .ptime { font-family: var(--font-mono); font-size: var(--fs-xs); color: var(--text-tertiary); flex: none; }
 .seek { flex: 1; height: 5px; border-radius: var(--r-pill); background: var(--bg-tertiary); position: relative; cursor: pointer; }
 .seekAt { position: absolute; left: 0; top: 0; bottom: 0; width: 28%; background: var(--accent-primary); border-radius: var(--r-pill); }
+
+/* ---- responsive ---- */
+@media (max-width: 1023px) {
+  .body { flex-direction: column; overflow: auto; min-height: auto; }
+  .split { flex-direction: column; min-height: auto; }
+  .ctrl { width: 100%; flex: none; border-right: 0; border-bottom: 1px solid var(--border-subtle); overflow-y: visible; }
+  .output { min-height: 0; }
+  .scroll { overflow-y: visible; }
+}
+@media (max-width: 767px) {
+  .jobbar { padding: var(--sp-2) var(--sp-3); }
+  .ctrl { padding: var(--sp-4) var(--sp-3); }
+  .scroll { padding: var(--sp-3); }
+  .segment { flex-direction: column; gap: var(--sp-2); }
+  .segMeta { width: auto; }
+  .outputTop, .player { padding: var(--sp-2) var(--sp-3); }
+}

--- a/frontend/app/components/AppBar.module.css
+++ b/frontend/app/components/AppBar.module.css
@@ -1,0 +1,33 @@
+.bar {
+  display: none;
+  height: 52px;
+  flex: none;
+  align-items: center;
+  gap: var(--sp-2);
+  padding: 0 var(--sp-3);
+  background: var(--bg-secondary);
+  border-bottom: 1px solid var(--border-subtle);
+}
+.logo { width: 24px; height: 24px; display: block; flex: none; }
+.title {
+  flex: 1; min-width: 0;
+  font-family: var(--font-display); font-size: var(--fs-md);
+  font-weight: var(--fw-semibold); letter-spacing: var(--ls-tight);
+  color: var(--text-primary);
+  overflow: hidden; text-overflow: ellipsis; white-space: nowrap;
+}
+.act {
+  border: 0; background: transparent; color: var(--text-secondary);
+  padding: var(--sp-1); border-radius: var(--r-sm); display: flex;
+}
+.ico {
+  width: 20px; height: 20px; stroke: currentColor; fill: none;
+  stroke-width: 1.5; stroke-linecap: round; stroke-linejoin: round;
+}
+
+@media (max-width: 767px) {
+  .bar {
+    display: flex;
+    position: fixed; top: 0; left: 0; right: 0; z-index: 40;
+  }
+}

--- a/frontend/app/components/AppBar.tsx
+++ b/frontend/app/components/AppBar.tsx
@@ -1,0 +1,21 @@
+'use client';
+
+import { usePathname } from 'next/navigation';
+
+import { pageTitle } from '@/lib/mobileNav';
+import NavIcon from './NavIcon';
+import s from './AppBar.module.css';
+
+export default function AppBar({ onMenu }: { onMenu: () => void }) {
+  const title = pageTitle(usePathname());
+
+  return (
+    <header className={s.bar}>
+      <img className={s.logo} src="/phoenix-ember.svg" alt="Phoenix" />
+      <span className={s.title}>{title}</span>
+      <button className={s.act} onClick={onMenu} aria-label="Open menu">
+        <NavIcon paths={['M2 4h12', 'M2 8h12', 'M2 12h12']} className={s.ico} />
+      </button>
+    </header>
+  );
+}

--- a/frontend/app/components/BottomNav.module.css
+++ b/frontend/app/components/BottomNav.module.css
@@ -1,0 +1,29 @@
+.bar {
+  display: none;
+  position: fixed;
+  bottom: 0; left: 0; right: 0;
+  z-index: 40;
+  height: 62px;
+  align-items: stretch;
+  background: var(--bg-secondary);
+  border-top: 1px solid var(--border-subtle);
+}
+.item {
+  flex: 1;
+  display: flex; flex-direction: column;
+  align-items: center; justify-content: center; gap: 2px;
+  border: 0; background: transparent;
+  color: var(--text-tertiary);
+  font-family: inherit; font-size: var(--fs-xs);
+  text-decoration: none;
+}
+.ico {
+  width: 20px; height: 20px; stroke: currentColor; fill: none;
+  stroke-width: 1.5; stroke-linecap: round; stroke-linejoin: round;
+}
+.active { color: var(--accent-ink); }
+.active .ico { filter: drop-shadow(0 0 4px var(--accent-primary)); }
+
+@media (max-width: 767px) {
+  .bar { display: flex; }
+}

--- a/frontend/app/components/BottomNav.tsx
+++ b/frontend/app/components/BottomNav.tsx
@@ -1,0 +1,38 @@
+'use client';
+
+import Link from 'next/link';
+import { usePathname } from 'next/navigation';
+
+import { bottomNavItems } from '@/lib/mobileNav';
+import NavIcon from './NavIcon';
+import s from './BottomNav.module.css';
+
+export default function BottomNav({ onMore }: { onMore: () => void }) {
+  const pathname = usePathname();
+  const isActive = (href: string) =>
+    href === '/' ? pathname === '/' : pathname === href || pathname.startsWith(`${href}/`);
+  const onPrimary = bottomNavItems.some((i) => isActive(i.href));
+
+  return (
+    <nav className={s.bar} aria-label="Primary mobile">
+      {bottomNavItems.map((item) => (
+        <Link
+          key={item.key}
+          href={item.href}
+          className={`${s.item} ${isActive(item.href) ? s.active : ''}`}
+        >
+          <NavIcon paths={item.icon} className={s.ico} />
+          <span>{item.label}</span>
+        </Link>
+      ))}
+      <button
+        className={`${s.item} ${onPrimary ? '' : s.active}`}
+        onClick={onMore}
+        aria-label="More"
+      >
+        <NavIcon paths={['M3.5 8h.01', 'M8 8h.01', 'M12.5 8h.01']} className={s.ico} />
+        <span>More</span>
+      </button>
+    </nav>
+  );
+}

--- a/frontend/app/components/MobileNav.tsx
+++ b/frontend/app/components/MobileNav.tsx
@@ -1,0 +1,18 @@
+'use client';
+
+import { useState } from 'react';
+
+import AppBar from './AppBar';
+import BottomNav from './BottomNav';
+import NavDrawer from './NavDrawer';
+
+export default function MobileNav() {
+  const [open, setOpen] = useState(false);
+  return (
+    <>
+      <AppBar onMenu={() => setOpen(true)} />
+      <BottomNav onMore={() => setOpen(true)} />
+      <NavDrawer open={open} onClose={() => setOpen(false)} />
+    </>
+  );
+}

--- a/frontend/app/components/NavDrawer.module.css
+++ b/frontend/app/components/NavDrawer.module.css
@@ -1,0 +1,26 @@
+.root {
+  position: fixed; inset: 0; z-index: 50;
+  visibility: hidden;
+  pointer-events: none;
+}
+.root.open { visibility: visible; pointer-events: auto; }
+
+.overlay {
+  position: absolute; inset: 0;
+  background: rgba(0, 0, 0, 0.5);
+  opacity: 0;
+  transition: opacity var(--dur-fast) var(--ease-default);
+}
+.root.open .overlay { opacity: 1; }
+
+.panel {
+  position: absolute; top: 0; bottom: 0; left: 0;
+  width: var(--size-sidebar); max-width: 84vw;
+  background: var(--bg-secondary);
+  box-shadow: var(--shadow-lg);
+  transform: translateX(-100%);
+  transition: transform var(--dur-normal) var(--ease-default);
+  display: flex;
+}
+.root.open .panel { transform: translateX(0); }
+.panel > * { width: 100%; }

--- a/frontend/app/components/NavDrawer.tsx
+++ b/frontend/app/components/NavDrawer.tsx
@@ -1,0 +1,20 @@
+'use client';
+
+import Sidebar from './Sidebar';
+import s from './NavDrawer.module.css';
+
+export default function NavDrawer({ open, onClose }: { open: boolean; onClose: () => void }) {
+  return (
+    <div className={`${s.root} ${open ? s.open : ''}`} aria-hidden={!open}>
+      <div className={s.overlay} onClick={onClose} />
+      <div
+        className={s.panel}
+        onClick={(e) => {
+          if ((e.target as HTMLElement).closest('a')) onClose();
+        }}
+      >
+        <Sidebar />
+      </div>
+    </div>
+  );
+}

--- a/frontend/app/globals.css
+++ b/frontend/app/globals.css
@@ -59,3 +59,10 @@ button {
   min-width: 0;
   overflow: hidden;
 }
+
+.deskNav { display: contents; }
+
+@media (max-width: 767px) {
+  .deskNav { display: none; }
+  .main { padding-top: 52px; padding-bottom: 62px; }
+}

--- a/frontend/lib/mobileNav.ts
+++ b/frontend/lib/mobileNav.ts
@@ -1,0 +1,17 @@
+import { footerItem, navGroups, type NavItem } from './nav';
+
+export const bottomNavItems: NavItem[] = [
+  { key: 'home', label: 'Home', href: '/', icon: ['M2.5 7.5 8 2.5l5.5 5', 'M4 6.5V13h8V6.5', 'M6.5 13V9.5h3V13'] },
+  { key: 'chat', label: 'Chat', href: '/chat', icon: ['M2 3h12v8H6l-3 2.4V11H2z'] },
+  { key: 'models', label: 'Models', href: '/models', icon: ['M4.5 4.5h7v7h-7z', 'M6.5 2v2.5M9.5 2v2.5M6.5 11.5V14M9.5 11.5V14M2 6.5h2.5M2 9.5h2.5M11.5 6.5H14M11.5 9.5H14'] },
+  { key: 'docs', label: 'Docs', href: '/documents', icon: ['M9 1.8H4.6a1 1 0 0 0-1 1v10.4a1 1 0 0 0 1 1h6.8a1 1 0 0 0 1-1V4.8z', 'M9 1.8V5h3.4'] },
+];
+
+const allItems: NavItem[] = [...navGroups.flatMap((g) => g.items), footerItem];
+
+export function pageTitle(pathname: string): string {
+  const match = allItems
+    .filter((i) => (i.href === '/' ? pathname === '/' : pathname === i.href || pathname.startsWith(`${i.href}/`)))
+    .sort((a, b) => b.href.length - a.href.length)[0];
+  return match?.label ?? 'Phoenix';
+}


### PR DESCRIPTION
Mobile app shell (≤767px): AppBar (logo + page title + menu), fixed BottomNav (Home/Chat/Models/Docs/More), and a slide-in NavDrawer that reuses the sidebar nav. Sidebar is retained at ≥768px.

Per-page reflow: every multi-column grid collapses to one column on mobile, dense grids step down on tablet, two-pane splits stack, and fixed-width tables scroll instead of clipping. Desktop unchanged.


