### PR TITLE
harden(gateway): localhost CORS guard + installer tar-slip guard + cleanup

### DIFF
--- a/install/install
+++ b/install/install
@@ -113,7 +113,13 @@ install_artifact() {
 
   rm -rf "${dest}"
   mkdir -p "${TMP_DIR}/extract"
-  tar -xzf "${TMP_DIR}/${artifact}" -C "${TMP_DIR}/extract"
+  # Refuse absolute paths or `..` traversal before extracting (tar-slip guard;
+  # parity with install.py's filter="data").
+  if tar -tzf "${TMP_DIR}/${artifact}" | grep -Eq '(^/|(^|/)\.\.(/|$))'; then
+    print_err "unsafe paths in ${artifact} — refusing to extract"
+    return 1
+  fi
+  tar -xzf "${TMP_DIR}/${artifact}" -C "${TMP_DIR}/extract" --no-same-owner
   local inner
   inner="$(find "${TMP_DIR}/extract" -mindepth 1 -maxdepth 1 -type d | head -n1)"
   mkdir -p "${INSTALL_ROOT}"

--- a/packages/phoenix_server/lib/src/messages_api.dart
+++ b/packages/phoenix_server/lib/src/messages_api.dart
@@ -22,14 +22,16 @@ Router messagesApi(CompletionEngine engine, ModelManager models) {
       return _anthropicError(400, 'invalid_request_error', 'max_tokens is required');
     }
 
-    final messages = _parseMessages(messagesRaw, system: _anthropicSystem(body['system']));
-    if (messages.every((m) => m.role == 'system')) {
+    final messages = _parseMessages(messagesRaw);
+    if (messages.isEmpty) {
       return _anthropicError(400, 'invalid_request_error', 'messages must include user content');
     }
 
     final modelName = body['model'] as String?;
     final temperature = (body['temperature'] as num?)?.toDouble();
     final stream = body['stream'] as bool? ?? false;
+    // The Anthropic top-level `system` is the single source of system prompt;
+    // CompletionEngine.complete applies it directly.
     final system = _anthropicSystem(body['system']);
 
     try {
@@ -96,11 +98,8 @@ Router messagesApi(CompletionEngine engine, ModelManager models) {
   return r;
 }
 
-List<ApiMessage> _parseMessages(List<dynamic> raw, {String system = ''}) {
+List<ApiMessage> _parseMessages(List<dynamic> raw) {
   final out = <ApiMessage>[];
-  if (system.isNotEmpty) {
-    out.add(ApiMessage('system', system));
-  }
   for (final item in raw) {
     if (item is! Map<String, dynamic>) continue;
     final role = item['role'] as String? ?? '';

--- a/packages/phoenix_server/lib/src/models_api.dart
+++ b/packages/phoenix_server/lib/src/models_api.dart
@@ -90,16 +90,36 @@ Handler buildGatewayHandler(PhoenixCore core) {
   return const Pipeline().addMiddleware(_cors()).addHandler(router.call);
 }
 
-const _corsHeaders = {
-  'Access-Control-Allow-Origin': '*',
+/// A request Origin is only trusted when it is loopback. CLI/SDK clients
+/// (curl, the Dart/Python SDKs) send no Origin at all and pass through.
+bool _isLocalhostOrigin(String origin) {
+  final uri = Uri.tryParse(origin);
+  if (uri == null) return false;
+  return uri.host == '127.0.0.1' || uri.host == 'localhost' || uri.host == '::1';
+}
+
+Map<String, String> _corsHeadersFor(String? origin) => {
+  // Reflect a trusted loopback origin; fall back to `*` only when no browser
+  // Origin is present (non-browser clients), never for a foreign site.
+  'Access-Control-Allow-Origin': (origin == null || origin.isEmpty) ? '*' : origin,
   'Access-Control-Allow-Methods': 'GET, POST, DELETE, OPTIONS',
   'Access-Control-Allow-Headers': 'Content-Type, Authorization, x-api-key, anthropic-version',
+  'Vary': 'Origin',
 };
 
 Middleware _cors() => (handler) => (req) async {
-  if (req.method == 'OPTIONS') return Response.ok(null, headers: _corsHeaders);
+  final origin = req.headers['origin'];
+  // Block cross-site browser callers (DNS-rebind / localhost CSRF). A malicious
+  // page the user visits must not be able to drive or delete local models.
+  if (origin != null && origin.isNotEmpty && !_isLocalhostOrigin(origin)) {
+    return Response.forbidden(
+      jsonEncode({'error': 'cross-origin requests are not allowed on the local gateway'}),
+      headers: {'content-type': 'application/json'},
+    );
+  }
+  if (req.method == 'OPTIONS') return Response.ok(null, headers: _corsHeadersFor(origin));
   final res = await handler(req);
-  return res.change(headers: _corsHeaders);
+  return res.change(headers: _corsHeadersFor(origin));
 };
 
 Future<AiModel?> _find(ModelManager manager, String id) async {

--- a/packages/phoenix_server/test/models_api_test.dart
+++ b/packages/phoenix_server/test/models_api_test.dart
@@ -93,4 +93,19 @@ void main() {
   test('unknown id → 404', () async {
     expect((await call('POST', '/v1/models/999/select')).statusCode, 404);
   });
+
+  Future<Response> callWithOrigin(String origin) async => handler(
+    Request('GET', Uri.parse('http://localhost/v1/models'), headers: {'origin': origin}),
+  );
+
+  test('cross-site Origin is rejected with 403', () async {
+    final res = await callWithOrigin('https://evil.example');
+    expect(res.statusCode, 403);
+  });
+
+  test('loopback Origin is allowed and reflected', () async {
+    final res = await callWithOrigin('http://127.0.0.1:24678');
+    expect(res.statusCode, 200);
+    expect(res.headers['access-control-allow-origin'], 'http://127.0.0.1:24678');
+  });
 }


### PR DESCRIPTION
## Summary
Audit follow-ups from the Phoenix gateway (#56). Security + cleanup, no behavior change for CLI/SDK clients.

- **CORS / localhost guard** (`models_api.dart`) — reject cross-site browser Origins (DNS-rebind / localhost CSRF); reflect only loopback origins, `*` when no Origin present. `curl`/SDKs send no Origin and are unaffected. **+2 regression tests.**
- **Dead-code cleanup** (`messages_api.dart`) — remove the inert prepended system message and the duplicate `_anthropicSystem()` call; the Anthropic top-level `system` is now the single source.
- **Installer tar-slip guard** (`install`, bash) — refuse absolute / `..` entries before extraction (parity with `install.py` `filter="data"`); extract with `--no-same-owner`.

## Test plan
`python3 install/verify.py` → `✓ all verification checks passed` — core 41, server **20** (+2), cli 2, live e2e (health→models→chat→stream→messages). `bash -n install/install` clean.

## Deferred (separate PR)
Multi-turn chat-template formatting: the engine exposes a flat `prompt_template` only; correct templating needs `llama_chat_apply_template` or per-model templates. Tracked from `docs/AUDIT.md`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)