### PR TITLE
docs(legal): add NEMATI AI LLC company information

### DIFF
--- a/NOTICE
+++ b/NOTICE
@@ -1,0 +1,14 @@
+Phoenix
+Copyright (C) 2023–2026 NEMATI AI LLC
+
+This product is developed and maintained by NEMATI AI LLC, a Wisconsin
+domestic limited liability company (Entity ID D075329).
+
+Registered office:
+  NEMATI AI LLC
+  7343 N Teutonia Ave, Apt 7
+  Milwaukee, WI 53209-2051
+  United States
+
+Phoenix is free software licensed under the GNU Affero General Public
+License v3.0. See the LICENSE file for the full terms.

--- a/README.md
+++ b/README.md
@@ -140,4 +140,12 @@ without a monolithic shell.
 [Docling](https://github.com/docling-project/docling) ·
 [whisper.cpp](https://github.com/ggerganov/whisper.cpp)
 
-<div align="center"><sub>Built with 🔥 by the osllmai community — <a href="https://github.com/osllmai/phoenix">star us on GitHub</a>.</sub></div>
+## License
+
+Phoenix is licensed under the [GNU Affero General Public License v3.0](LICENSE).
+
+Copyright © 2023–2026 **NEMATI AI LLC** — a Wisconsin limited liability company
+(Entity ID D075329), 7343 N Teutonia Ave, Apt 7, Milwaukee, WI 53209-2051, USA.
+See [`NOTICE`](NOTICE) for details.
+
+<div align="center"><sub>Built with 🔥 by NEMATI AI LLC and the osllmai community — <a href="https://github.com/osllmai/phoenix">star us on GitHub</a>.</sub></div>

--- a/frontend/app/(marketing)/landing/page.tsx
+++ b/frontend/app/(marketing)/landing/page.tsx
@@ -68,11 +68,12 @@ export default function LandingPage() {
             <Image src="/phoenix-ember.svg" alt="" width={20} height={20} />
             Phoenix
           </span>
-          <span>© 2026 · Local-first AI</span>
+          <span>© 2026 NEMATI AI LLC · Local-first AI</span>
           <span className={s.footLinks}>
             <a href="#">GitHub</a>
             <a href="#">Docs</a>
             <a href="#">Privacy</a>
+            <a href="/legal">Legal</a>
             <a href="/welcome">Download</a>
           </span>
         </div>

--- a/frontend/app/(marketing)/legal/page.module.css
+++ b/frontend/app/(marketing)/legal/page.module.css
@@ -1,0 +1,134 @@
+.page {
+  min-height: 100vh;
+  background: var(--bg-primary);
+  color: var(--text-primary);
+  padding: 72px 24px 96px;
+}
+
+.wrap {
+  max-width: 720px;
+  margin: 0 auto;
+}
+
+.eyebrow {
+  margin: 0 0 8px;
+  font-size: 12px;
+  font-weight: 600;
+  letter-spacing: 0.1em;
+  text-transform: uppercase;
+  color: var(--accent-primary);
+}
+
+.title {
+  margin: 0 0 12px;
+  font-size: 34px;
+  line-height: 1.1;
+  letter-spacing: -0.02em;
+  text-wrap: balance;
+}
+
+.lede {
+  margin: 0 0 32px;
+  max-width: 56ch;
+  color: var(--text-secondary);
+  font-size: 16px;
+  line-height: 1.6;
+}
+
+.card {
+  background: var(--bg-secondary);
+  border: 1px solid var(--border-default);
+  border-radius: 14px;
+  padding: 20px 22px;
+  margin-bottom: 16px;
+}
+
+.cardTitle {
+  margin: 0 0 14px;
+  font-size: 12px;
+  font-weight: 600;
+  letter-spacing: 0.08em;
+  text-transform: uppercase;
+  color: var(--text-tertiary);
+}
+
+.split {
+  display: grid;
+  grid-template-columns: 1fr 1fr;
+  gap: 16px;
+}
+
+.split .card {
+  margin-bottom: 16px;
+}
+
+.rows {
+  margin: 0;
+  display: flex;
+  flex-direction: column;
+  gap: 10px;
+}
+
+.row {
+  display: flex;
+  justify-content: space-between;
+  align-items: baseline;
+  gap: 16px;
+  padding-bottom: 10px;
+  border-bottom: 1px solid var(--border-default);
+}
+
+.row:last-child {
+  padding-bottom: 0;
+  border-bottom: 0;
+}
+
+.k {
+  color: var(--text-secondary);
+  font-size: 14px;
+}
+
+.v {
+  margin: 0;
+  font-weight: 600;
+  font-size: 14px;
+  text-align: right;
+  font-variant-numeric: tabular-nums;
+}
+
+.addr {
+  font-style: normal;
+  line-height: 1.7;
+  color: var(--text-primary);
+  font-size: 15px;
+}
+
+.body {
+  margin: 0;
+  color: var(--text-secondary);
+  font-size: 15px;
+  line-height: 1.6;
+}
+
+.back {
+  margin-top: 28px;
+  font-size: 14px;
+}
+
+.back a {
+  color: var(--text-link);
+  text-decoration: none;
+}
+
+.back a:hover {
+  text-decoration: underline;
+}
+
+@media (max-width: 620px) {
+  .split {
+    grid-template-columns: 1fr;
+  }
+  .title {
+    font-size: 28px;
+  }
+}

--- a/frontend/app/(marketing)/legal/page.tsx
+++ b/frontend/app/(marketing)/legal/page.tsx
@@ -1,0 +1,80 @@
+import type { Metadata } from 'next';
+import Link from 'next/link';
+
+import s from './page.module.css';
+
+export const metadata: Metadata = {
+  title: 'Legal — Phoenix',
+  description: 'Company information and legal notices for Phoenix, operated by NEMATI AI LLC.',
+};
+
+const COMPANY = [
+  ['Legal name', 'NEMATI AI LLC'],
+  ['Entity type', 'Domestic Limited Liability Company'],
+  ['Jurisdiction', 'Wisconsin, United States'],
+  ['Entity ID', 'D075329'],
+  ['Effective date', 'February 15, 2023'],
+  ['Status', 'Good Standing'],
+] as const;
+
+export default function LegalPage() {
+  return (
+    <main className={s.page}>
+      <div className={s.wrap}>
+        <p className={s.eyebrow}>Legal</p>
+        <h1 className={s.title}>Company information</h1>
+        <p className={s.lede}>
+          Phoenix is developed and operated by NEMATI AI LLC. The details below reflect
+          the company&rsquo;s registration on public record.
+        </p>
+
+        <section className={s.card}>
+          <h2 className={s.cardTitle}>Company</h2>
+          <dl className={s.rows}>
+            {COMPANY.map(([k, v]) => (
+              <div className={s.row} key={k}>
+                <dt className={s.k}>{k}</dt>
+                <dd className={s.v}>{v}</dd>
+              </div>
+            ))}
+          </dl>
+        </section>
+
+        <div className={s.split}>
+          <section className={s.card}>
+            <h2 className={s.cardTitle}>Registered office</h2>
+            <address className={s.addr}>
+              NEMATI AI LLC<br />
+              7343 N Teutonia Ave, Apt 7<br />
+              Milwaukee, WI 53209-2051<br />
+              United States
+            </address>
+          </section>
+
+          <section className={s.card}>
+            <h2 className={s.cardTitle}>Registered agent</h2>
+            <address className={s.addr}>
+              Ali Nemati<br />
+              7343 N Teutonia Ave, Apt 7<br />
+              Milwaukee, WI 53209-2051<br />
+              United States
+            </address>
+          </section>
+        </div>
+
+        <section className={s.card}>
+          <h2 className={s.cardTitle}>License &amp; copyright</h2>
+          <p className={s.body}>
+            Phoenix is free software licensed under the GNU Affero General Public License v3.0.
+            Copyright &copy; 2023&ndash;2026 NEMATI AI LLC. All product names and marks are the
+            property of their respective owners.
+          </p>
+        </section>
+
+        <p className={s.back}>
+          <Link href="/landing">&larr; Back to Phoenix</Link>
+        </p>
+      </div>
+    </main>
+  );
+}

--- a/mobile/lib/features/settings/presentation/widgets/about_section.dart
+++ b/mobile/lib/features/settings/presentation/widgets/about_section.dart
@@ -37,6 +37,28 @@ class AboutSection extends StatelessWidget {
               ),
           ],
         ),
+        const SizedBox(height: 16),
+        SettingGroup(
+          children: [
+            Padding(
+              padding: const EdgeInsets.symmetric(vertical: 10),
+              child: Column(
+                crossAxisAlignment: CrossAxisAlignment.start,
+                children: [
+                  Text('NEMATI AI LLC', style: Theme.of(context).textTheme.bodyMedium),
+                  const SizedBox(height: 4),
+                  Text(
+                    'Domestic LLC · Wisconsin, USA · Entity ID D075329\n'
+                    '7343 N Teutonia Ave, Apt 7, Milwaukee, WI 53209-2051\n'
+                    '© 2023–2026 NEMATI AI LLC · AGPL-3.0',
+                    style: Theme.of(context).textTheme.bodySmall
+                        ?.copyWith(color: scheme.onSurfaceVariant, height: 1.5),
+                  ),
+                ],
+              ),
+            ),
+          ],
+        ),
         Wrap(
           spacing: 12,
           runSpacing: 12,


### PR DESCRIPTION
## Summary
Surfaces the operating company across the product, using the details from the public Wisconsin DFI registry record.

- **`NOTICE`** (new) — AGPL copyright holder + registered office.
- **`README`** — new **License** section (copyright + entity + address); footer now credits NEMATI AI LLC.
- **Marketing footer** — entity name in the © line + a new **Legal** link.
- **`/legal` page** (new) — company (Entity ID D075329, Wisconsin, USA), registered office & agent, license/copyright. Styled via the existing `tokens.css` variables, so it themes light/dark automatically.
- **Mobile About / Settings** — company + entity + address block under the version list.

## Company details rendered
NEMATI AI LLC · Domestic LLC (Wisconsin, USA) · Entity ID **D075329** · effective 2023-02-15 · Good Standing · 7343 N Teutonia Ave, Apt 7, Milwaukee, WI 53209-2051.

All fields shown are already public record.

## Not included (out of my scope)
This does **not** touch the actual state registration — filing the Annual Report or a Registered Agent/Office update must be done on the WI DFI portal.

## Test plan
- `/legal` renders under the marketing route group; footer link resolves.
- Frontend types not compiled locally (deps not installed) — verify in CI/preview.

🤖 Generated with [Claude Code](https://claude.com/claude-code)